### PR TITLE
Fix typo for cookbook_path manager tips

### DIFF
--- a/tips/with_cookbook_manager.md
+++ b/tips/with_cookbook_manager.md
@@ -12,7 +12,7 @@ This usage assumes using cookbook manager to manage both 3rd parties cookbooks a
 Set `berks vendor` to hooks.
 
 ```ruby
-coobook_path [
+cookbook_path [
   File.expand_path('../../berks-cookbooks', __FILE__)
 ]
 


### PR DESCRIPTION
Changed coobook_path  to cookbook_path in the tips section for Cookbook Managers.
